### PR TITLE
Add Prometheus metrics integration

### DIFF
--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -15,6 +15,7 @@
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using Etherna.DomainEvents;
+using Etherna.SSOServer.Configs.Metrics;
 using Etherna.SSOServer.Domain.Events;
 using Etherna.SSOServer.Domain.Models;
 using Etherna.SSOServer.Services.Extensions;
@@ -144,6 +145,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                 // Rise event and create log.
                 await eventDispatcher.DispatchAsync(new UserLoginSuccessEvent(user, clientId: context?.Client?.ClientId));
                 logger.LoggedInWithPassword(user.Id);
+                SsoMetrics.RecordLoginAttempt("password", "success");
 
                 // Identify redirect.
                 return await ContextedRedirectAsync(context, returnUrl);
@@ -157,12 +159,14 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             else if (result.IsLockedOut)
             {
                 logger.LockedOutLoginAttempt(user.Id);
+                SsoMetrics.RecordLoginAttempt("password", "locked_out");
                 return RedirectToPage("./Lockout");
             }
 
             else
             {
                 await eventDispatcher.DispatchAsync(new UserLoginFailureEvent(Input.UsernameOrEmail, "invalid credentials", clientId: context?.Client?.ClientId));
+                SsoMetrics.RecordLoginAttempt("password", "failure");
                 ModelState.AddModelError(string.Empty, "Invalid login attempt.");
                 return Page();
             }

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
@@ -15,6 +15,7 @@
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using Etherna.DomainEvents;
+using Etherna.SSOServer.Configs.Metrics;
 using Etherna.SSOServer.Domain.Events;
 using Etherna.SSOServer.Domain.Models;
 using Etherna.SSOServer.Services.Extensions;
@@ -111,6 +112,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                 // Rise event and create log.
                 await eventDispatcher.DispatchAsync(new UserLoginSuccessEvent(user, clientId: context?.Client?.ClientId));
                 logger.LoggedInWith2FA(user.Id);
+                SsoMetrics.RecordLoginAttempt("2fa", "success");
 
                 // Identify redirect.
                 return await ContextedRedirectAsync(context, returnUrl);
@@ -118,11 +120,13 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             else if (result.IsLockedOut)
             {
                 logger.LockedOutLoginAttempt(user.Id);
+                SsoMetrics.RecordLoginAttempt("2fa", "locked_out");
                 return RedirectToPage("./Lockout");
             }
             else
             {
                 logger.Invalid2FACodeAttempt(user.Id);
+                SsoMetrics.RecordLoginAttempt("2fa", "failure");
                 ModelState.AddModelError(string.Empty, "Invalid authenticator code.");
                 return Page();
             }

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
 // If not, see <https://www.gnu.org/licenses/>.
 
+using Etherna.SSOServer.Configs.Metrics;
 using Etherna.SSOServer.Domain.Models;
 using Etherna.SSOServer.Services.Extensions;
 using Microsoft.AspNetCore.Authorization;
@@ -88,16 +89,19 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             if (result.Succeeded)
             {
                 logger.LoggedInWithRecoveryCode(user.Id);
+                SsoMetrics.RecordLoginAttempt("recovery_code", "success");
                 return LocalRedirect(returnUrl ?? Url.Content("~/"));
             }
             if (result.IsLockedOut)
             {
                 logger.LockedOutLoginAttempt(user.Id);
+                SsoMetrics.RecordLoginAttempt("recovery_code", "locked_out");
                 return RedirectToPage("./Lockout");
             }
             else
             {
                 logger.InvalidRecoveryCodeAttempt(user.Id);
+                SsoMetrics.RecordLoginAttempt("recovery_code", "failure");
                 ModelState.AddModelError(string.Empty, "Invalid recovery code entered.");
                 return Page();
             }

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -14,6 +14,7 @@
 
 using Duende.IdentityServer.Services;
 using Etherna.DomainEvents;
+using Etherna.SSOServer.Configs.Metrics;
 using Etherna.SSOServer.Domain.Events;
 using Etherna.SSOServer.Domain.Helpers;
 using Etherna.SSOServer.Domain.Models;
@@ -139,6 +140,8 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                 // Rise event and create log.
                 await eventDispatcher.DispatchAsync(new UserLoginSuccessEvent(user, clientId: context?.Client?.ClientId));
                 logger.CreatedAccountWithPassword(user.Id);
+                SsoMetrics.RecordRegistration("password");
+                SsoMetrics.RecordLoginAttempt("password", "success");
 
                 // Redirect to add verified email page.
                 return RedirectToPage("SetVerifiedEmail", new { returnUrl });

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml.cs
@@ -17,6 +17,7 @@ using Duende.IdentityServer.Stores;
 using Etherna.BeeNet.Models;
 using Etherna.DomainEvents;
 using Etherna.MongoDB.Driver;
+using Etherna.SSOServer.Configs.Metrics;
 using Etherna.SSOServer.Domain;
 using Etherna.SSOServer.Domain.Events;
 using Etherna.SSOServer.Domain.Helpers;
@@ -174,6 +175,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                     provider: "web3",
                     providerUserId: etherAddress.ToString()));
                 logger.LoggedInWithWeb3(user.Id);
+                SsoMetrics.RecordLoginAttempt("web3", "success");
 
                 // Identify redirect.
                 return await ContextedRedirectAsync(context, returnUrl);
@@ -233,6 +235,8 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                     provider: "web3",
                     providerUserId: etherAddress));
                 logger.CreatedAccountWithWeb3(user.Id);
+                SsoMetrics.RecordRegistration("web3");
+                SsoMetrics.RecordLoginAttempt("web3", "success");
 
                 // Redirect to add verified email page.
                 return RedirectToPage("SetVerifiedEmail", new { returnUrl });

--- a/src/EthernaSSO/Configs/IdentityServer/ApiKeyValidator.cs
+++ b/src/EthernaSSO/Configs/IdentityServer/ApiKeyValidator.cs
@@ -14,6 +14,7 @@
 
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Validation;
+using Etherna.SSOServer.Configs.Metrics;
 using Etherna.SSOServer.Domain;
 using Etherna.SSOServer.Domain.Models;
 using Etherna.SSOServer.Services.Extensions;
@@ -68,6 +69,7 @@ namespace Etherna.SSOServer.Configs.IdentityServer
             if (await userManager.IsLockedOutAsync(user))
             {
                 logger.LockedOutLoginAttempt(userId);
+                SsoMetrics.RecordLoginAttempt("api_key", "locked_out");
                 context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "User is locked out.");
                 return;
             }
@@ -76,6 +78,7 @@ namespace Etherna.SSOServer.Configs.IdentityServer
             if (!await signInManager.CanSignInAsync(user))
             {
                 logger.NotAllowedSingInLoginAttempt(userId);
+                SsoMetrics.RecordLoginAttempt("api_key", "failure");
                 context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "User is not allowed to sign in.");
                 return;
             }
@@ -89,6 +92,7 @@ namespace Etherna.SSOServer.Configs.IdentityServer
                 await userManager.AccessFailedAsync(user);
 
                 logger.ApiKeyDoesNotExistLoginAttempt(userId);
+                SsoMetrics.RecordLoginAttempt("api_key", "failure");
                 context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Api key does not exist.");
                 return;
             }
@@ -97,6 +101,7 @@ namespace Etherna.SSOServer.Configs.IdentityServer
             if (!apiKey.IsAlive)
             {
                 logger.ApiKeyIsNotAliveLoginAttempt(userId);
+                SsoMetrics.RecordLoginAttempt("api_key", "failure");
                 context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Api key is not alive.");
                 return;
             }
@@ -105,6 +110,7 @@ namespace Etherna.SSOServer.Configs.IdentityServer
             //TODO
 
             logger.ApiKeyValidatedLoginAttempt(userId);
+            SsoMetrics.RecordLoginAttempt("api_key", "success");
 
             context.Result = new GrantValidationResult(
                 userId,

--- a/src/EthernaSSO/Configs/Metrics/SsoMetrics.cs
+++ b/src/EthernaSSO/Configs/Metrics/SsoMetrics.cs
@@ -1,0 +1,45 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+namespace Etherna.SSOServer.Configs.Metrics
+{
+    using Prometheus;
+
+    public static class SsoMetrics
+    {
+        // Fields.
+        private static readonly Counter loginAttempts = Metrics.CreateCounter(
+            "sso_login_attempts_total",
+            "Total login attempts.",
+            new CounterConfiguration
+            {
+                LabelNames = ["method", "result"]
+            });
+
+        private static readonly Counter registrations = Metrics.CreateCounter(
+            "sso_account_registrations_total",
+            "Total account registrations.",
+            new CounterConfiguration
+            {
+                LabelNames = ["method"]
+            });
+
+        // Methods.
+        public static void RecordLoginAttempt(string method, string result) =>
+            loginAttempts.WithLabels(method, result).Inc();
+
+        public static void RecordRegistration(string method) =>
+            registrations.WithLabels(method).Inc();
+    }
+}

--- a/src/EthernaSSO/EthernaSSO.csproj
+++ b/src/EthernaSSO/EthernaSSO.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="MongODM" Version="0.25.0-alpha.54" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="MongODM.AspNetCore.UI" Version="0.25.0-alpha.54" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/src/EthernaSSO/Program.cs
+++ b/src/EthernaSSO/Program.cs
@@ -58,6 +58,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
+using Prometheus;
 using Scalar.AspNetCore;
 using Serilog;
 using Serilog.Exceptions;
@@ -570,6 +571,8 @@ namespace Etherna.SSOServer
 
             app.UseRouting();
 
+            app.UseHttpMetrics();
+
             app.UseCookiePolicy();
             app.UseAuthentication();
             app.UseIdentityServer();
@@ -605,6 +608,10 @@ namespace Etherna.SSOServer
                         flow.SelectedScopes = ["openid", "profile", "ether_accounts", "role", "userApi.sso"];
                     });
             });
+
+            // Prometheus metrics scrape endpoint.
+            // Access restricted at reverse proxy / network level.
+            app.MapMetrics("/metrics");
 
             // Register cron tasks.
             RecurringJob.AddOrUpdate<ICleanupOldFailedTasksTask>(


### PR DESCRIPTION
Integrate Prometheus to track SSO operations, including login attempts and account registrations, with HTTP metrics and custom counters. Add `/metrics` endpoint for scraping.