### PR TITLE
Integrate optional newsletter subscription (ESSO-189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ source together with its build and deployment configuration.
   password reset and account recovery.
 - **Web3 login** — sign in by proving control of an Ethereum address via a challenge/response, and link an
   Ethereum address to an existing account.
+- **Newsletter opt-in** — optional: during email verification the user can opt in (a verified email is then
+  required), or later from the account email settings (a button shown only when not already subscribed). The
+  verified contact is forwarded to an external newsletter service (e.g. Mailchimp) that owns the allowed list;
+  SSO emails are never used for non-technical communications. Disabled by default.
 - **Two-factor authentication** — TOTP authenticator apps, FIDO2/WebAuthn security keys (YubiKey, Touch ID,
   Windows Hello, …) and single-use recovery codes; at login a registered security key is preferred when no
   authenticator app is configured.
@@ -130,6 +134,16 @@ Secrets (`*Password`, `*ServiceKey`, `*Secret`, `Duende:IdentityServer:LicenseKe
 | `Email:ServiceUser` | — | provider user (Mailtrap) |
 | `Email:DisplayName` | `Etherna` | sender display name |
 | `Email:SendingAddress` | `noreply@etherna.io` | sender address |
+
+### Newsletter
+
+Optional, opt-in only: a user can subscribe to the newsletter during email verification or later from the account email settings (see [Features](#features)). The verified contact is forwarded to the configured newsletter service, which owns the allowed list — emails stored in the SSO db are never used for non-technical communications. Disabled by default (`FakeService`, a no-op).
+
+| Key | Default | Notes |
+|---|---|---|
+| `Newsletter:CurrentService` | `FakeService` | `Mailchimp` \| `FakeService` |
+| `Newsletter:ApiKey` | — | **secret** — Mailchimp API key (includes the `-<dc>` data-center suffix) |
+| `Newsletter:AudienceId` | — | Mailchimp audience (list) id |
 
 ### FIDO2 / WebAuthn (security-key 2FA)
 

--- a/src/EthernaSSO.Services/Domain/INewsletterService.cs
+++ b/src/EthernaSSO.Services/Domain/INewsletterService.cs
@@ -1,0 +1,48 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System.Threading.Tasks;
+
+namespace Etherna.SSOServer.Services.Domain
+{
+    /// <summary>
+    /// Where a newsletter subscription originated. The newsletter service maps it to the contact tag,
+    /// so callers don't deal with provider-specific tag strings.
+    /// </summary>
+    public enum NewsletterSubscriptionSource
+    {
+        Registration,
+        AccountSettings
+    }
+
+    public interface INewsletterService
+    {
+        /// <summary>
+        /// Add an email contact to the newsletter allowed list (managed by the external newsletter service).
+        /// The email must already be verified by the caller: emails stored in the SSO db are never used to
+        /// send non-technical communications, the contact is delegated to the newsletter service instead.
+        /// The operation is idempotent (add-or-update): subscribing an already-subscribed contact is a no-op.
+        /// </summary>
+        /// <param name="email">The verified email address to subscribe.</param>
+        /// <param name="source">Where the subscription originated (the service maps it to a contact tag).</param>
+        Task SubscribeEmailAsync(string email, NewsletterSubscriptionSource source);
+
+        /// <summary>
+        /// Whether the given email is currently subscribed to the newsletter allowed list. Returns false
+        /// when the service is disabled or the status cannot be determined (the subscribe call is idempotent).
+        /// </summary>
+        /// <param name="email">The email address to check.</param>
+        Task<bool> IsSubscribedAsync(string email);
+    }
+}

--- a/src/EthernaSSO.Services/Domain/NewsletterService.cs
+++ b/src/EthernaSSO.Services/Domain/NewsletterService.cs
@@ -1,0 +1,139 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SSOServer.Domain.Helpers;
+using Etherna.SSOServer.Services.Extensions;
+using Etherna.SSOServer.Services.Options;
+using MailChimp.Net;
+using MailChimp.Net.Core;
+using MailChimp.Net.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Etherna.SSOServer.Services.Domain
+{
+    public sealed class NewsletterService : INewsletterService
+    {
+        // Fields.
+        private readonly ILogger<NewsletterService> logger;
+        private readonly NewsletterOptions options;
+
+        // Constructor.
+        public NewsletterService(
+            ILogger<NewsletterService> logger,
+            IOptions<NewsletterOptions> opts)
+        {
+            ArgumentNullException.ThrowIfNull(opts);
+
+            this.logger = logger;
+            options = opts.Value;
+        }
+
+        // Methods.
+        public Task SubscribeEmailAsync(string email, NewsletterSubscriptionSource source)
+        {
+            if (!EmailHelper.IsValidEmail(email))
+                throw new ArgumentException("Email is not valid", nameof(email));
+
+            return options.CurrentService switch
+            {
+                NewsletterOptions.NewsletterService.Mailchimp => MailchimpSubscribeAsync(email, source),
+                NewsletterOptions.NewsletterService.FakeService => Task.CompletedTask,
+                _ => throw new InvalidOperationException()
+            };
+        }
+
+        public Task<bool> IsSubscribedAsync(string email)
+        {
+            if (!EmailHelper.IsValidEmail(email))
+                throw new ArgumentException("Email is not valid", nameof(email));
+
+            return options.CurrentService switch
+            {
+                NewsletterOptions.NewsletterService.Mailchimp => MailchimpIsSubscribedAsync(email),
+                NewsletterOptions.NewsletterService.FakeService => Task.FromResult(false),
+                _ => throw new InvalidOperationException()
+            };
+        }
+
+        // Helpers.
+        private static string SourceTag(NewsletterSubscriptionSource source) => source switch
+        {
+            NewsletterSubscriptionSource.Registration => "sso-registration",
+            NewsletterSubscriptionSource.AccountSettings => "sso-account",
+            _ => throw new InvalidOperationException()
+        };
+
+        private async Task MailchimpSubscribeAsync(string email, NewsletterSubscriptionSource source)
+        {
+            try
+            {
+                var manager = new MailChimpManager(options.ApiKey);
+
+                // The email has already been verified by the SSO before this call, so a single opt-in
+                // (no Mailchimp double opt-in) is enough: add or update the contact as subscribed.
+                await manager.Members.AddOrUpdateAsync(
+                    options.AudienceId,
+                    new Member
+                    {
+                        EmailAddress = email,
+                        Status = Status.Subscribed,
+                        StatusIfNew = Status.Subscribed
+                    });
+
+                // Tag the contact with its origin, to segment the single audience by source.
+                await manager.Members.AddTagsAsync(
+                    options.AudienceId,
+                    email,
+                    new Tags { MemberTags = [new Tag { Name = SourceTag(source), Status = "active" }] });
+            }
+            catch (MailChimpException ex)
+            {
+                // A newsletter-service failure must never block account registration: we only log it
+                // (no consent is stored on our side, so the user can simply opt in again later).
+                logger.NewsletterSubscriptionFailed(email, ex);
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.NewsletterSubscriptionFailed(email, ex);
+            }
+        }
+
+        private async Task<bool> MailchimpIsSubscribedAsync(string email)
+        {
+            try
+            {
+                var manager = new MailChimpManager(options.ApiKey);
+
+                // Defaults: falseIfUnsubscribed = true → returns true only if the contact is currently subscribed.
+                return await manager.Members.ExistsAsync(options.AudienceId, email);
+            }
+            catch (MailChimpException ex)
+            {
+                // If we can't read the status, report "not subscribed": the subscribe call is idempotent,
+                // so at worst the user is offered the button and an add-or-update is performed.
+                logger.NewsletterStatusCheckFailed(email, ex);
+                return false;
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.NewsletterStatusCheckFailed(email, ex);
+                return false;
+            }
+        }
+    }
+}

--- a/src/EthernaSSO.Services/EthernaSSO.Services.csproj
+++ b/src/EthernaSSO.Services/EthernaSSO.Services.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="8.0.2" />
     <PackageReference Include="Etherna.DomainEvents.AspNetCore" Version="1.5.0" />
     <PackageReference Include="Fido2" Version="4.0.1" />
+    <PackageReference Include="MailChimp.Net.V3" Version="5.8.2" />
     <PackageReference Include="MongODM.Hangfire" Version="0.25.0-alpha.55" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
   </ItemGroup>

--- a/src/EthernaSSO.Services/Extensions/LoggerExtensions.cs
+++ b/src/EthernaSSO.Services/Extensions/LoggerExtensions.cs
@@ -19,7 +19,7 @@ namespace Etherna.SSOServer.Services.Extensions
 {
     /*
      * Always group similar log delegates by type, always use incremental event ids.
-     * Last event id is: 46
+     * Last event id is: 48
      */
     public static class LoggerExtensions
     {
@@ -279,6 +279,18 @@ namespace Etherna.SSOServer.Services.Extensions
                 new EventId(4, nameof(LockedOutLoginAttempt)),
                 "User with ID '{UserId}' failed login attempt because account is locked out.");
 
+        private static readonly Action<ILogger, string, Exception> _newsletterStatusCheckFailed =
+            LoggerMessage.Define<string>(
+                LogLevel.Warning,
+                new EventId(48, nameof(NewsletterStatusCheckFailed)),
+                "Failed to read newsletter subscription status for email '{Email}'.");
+
+        private static readonly Action<ILogger, string, Exception> _newsletterSubscriptionFailed =
+            LoggerMessage.Define<string>(
+                LogLevel.Warning,
+                new EventId(47, nameof(NewsletterSubscriptionFailed)),
+                "Failed to subscribe email '{Email}' to the newsletter service.");
+
         private static readonly Action<ILogger, string, Exception> _notAllowedSingInLoginAttempt =
             LoggerMessage.Define<string>(
                 LogLevel.Warning,
@@ -396,6 +408,12 @@ namespace Etherna.SSOServer.Services.Extensions
 
         public static void LoggedInWithWeb3(this ILogger logger, string userId) =>
             _loggedInWithWeb3(logger, userId, null!);
+
+        public static void NewsletterStatusCheckFailed(this ILogger logger, string email, Exception exception) =>
+            _newsletterStatusCheckFailed(logger, email, exception);
+
+        public static void NewsletterSubscriptionFailed(this ILogger logger, string email, Exception exception) =>
+            _newsletterSubscriptionFailed(logger, email, exception);
 
         public static void NotAllowedSingInLoginAttempt(this ILogger logger, string userId) =>
             _notAllowedSingInLoginAttempt(logger, userId, null!);

--- a/src/EthernaSSO.Services/Options/NewsletterOptions.cs
+++ b/src/EthernaSSO.Services/Options/NewsletterOptions.cs
@@ -1,0 +1,29 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+namespace Etherna.SSOServer.Services.Options
+{
+    public sealed class NewsletterOptions
+    {
+        public enum NewsletterService
+        {
+            Mailchimp,
+            FakeService
+        }
+
+        public NewsletterService CurrentService { get; set; } = NewsletterService.FakeService;
+        public string ApiKey { get; set; } = null!;
+        public string AudienceId { get; set; } = null!;
+    }
+}

--- a/src/EthernaSSO.Services/ServiceCollectionExtensions.cs
+++ b/src/EthernaSSO.Services/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ namespace Etherna.SSOServer.Services
             //domain
             services.AddScoped<IEmailSender, EmailSender>();
             services.AddScoped<IFido2Service, Fido2Service>();
+            services.AddScoped<INewsletterService, NewsletterService>();
             services.AddScoped<IRazorViewRenderer, RazorViewRenderer>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IWeb3AuthnService, Web3AuthnService>();

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Email.cshtml
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Email.cshtml
@@ -32,5 +32,23 @@
             </div>
             <button id="change-email-button" type="submit" asp-page-handler="ChangeEmail" class="btn btn-primary">Change email</button>
         </form>
+
+        @if (Model.ShowNewsletterSection)
+        {
+            <hr />
+            <div class="mb-3">
+                <label class="form-label d-block">Newsletter</label>
+                @if (Model.SubscribedToNewsletter)
+                {
+                    <p class="text-success mb-0">You are subscribed to our newsletter.</p>
+                }
+                else
+                {
+                    <form id="newsletter-form" method="post">
+                        <button id="subscribe-newsletter-button" type="submit" asp-page-handler="SubscribeNewsletter" class="btn btn-primary">Subscribe to newsletter</button>
+                    </form>
+                }
+            </div>
+        }
     </div>
 </div>

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Email.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Email.cshtml.cs
@@ -29,6 +29,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
 {
     public class EmailModel(
         IEmailSender emailSender,
+        INewsletterService newsletterService,
         IRazorViewRenderer razorViewRenderer,
         ISsoDbContext ssoDbContext,
         UserManager<UserBase> userManager)
@@ -45,6 +46,9 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
 
         // Properties.
         public string? Email { get; set; }
+
+        public bool ShowNewsletterSection { get; set; }
+        public bool SubscribedToNewsletter { get; set; }
 
         [BindProperty]
         public InputModel Input { get; set; } = null!;
@@ -123,10 +127,37 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
             return RedirectToPage();
         }
 
+        public async Task<IActionResult> OnPostSubscribeNewsletterAsync()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user == null)
+                return NotFound($"Unable to load user with ID '{userManager.GetUserId(User)}'.");
+
+            var email = await userManager.GetEmailAsync(user);
+            if (email is null)
+            {
+                StatusMessage = new StatusMessage("You must add a verified email before subscribing.", StatusMessageType.Warning);
+                return RedirectToPage();
+            }
+
+            // Idempotent: the newsletter service performs an add-or-update on the allowed list, so a repeated
+            // call (or a double submit) is harmless.
+            await newsletterService.SubscribeEmailAsync(email, NewsletterSubscriptionSource.AccountSettings);
+
+            StatusMessage = new StatusMessage("You have been subscribed to our newsletter.");
+            return RedirectToPage();
+        }
+
         // Helpers.
         private async Task LoadAsync(UserBase user)
         {
             Email = await userManager.GetEmailAsync(user);
+
+            // Offer the newsletter section whenever the user has a (verified) email, regardless of whether the
+            // newsletter service is enabled: when disabled, IsSubscribedAsync reports "not subscribed" and the
+            // subscribe call is a no-op. The button is shown only when the contact is not already subscribed.
+            ShowNewsletterSection = Email is not null;
+            SubscribedToNewsletter = ShowNewsletterSection && await newsletterService.IsSubscribedAsync(Email!);
         }
     }
 }

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/SetVerifiedEmail.cshtml
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/SetVerifiedEmail.cshtml
@@ -34,6 +34,11 @@ else
             <div class="mb-3">
                 <label asp-for="EmailInput.Email"></label>
                 <input asp-for="EmailInput.Email" class="form-control" />
+                <div class="form-check mt-2">
+                    <input asp-for="EmailInput.SubscribeToNewsletter" class="form-check-input" />
+                    <label asp-for="EmailInput.SubscribeToNewsletter" class="form-check-label"></label>
+                    <small class="form-text text-muted d-block">A verified email is required to subscribe.</small>
+                </div>
                 <button type="submit" class="btn btn-secondary mt-2">Send code</button>
             </div>
         </form>
@@ -41,6 +46,7 @@ else
         <form asp-page-handler="ConfirmCode"
               asp-route-returnUrl="@Model.ReturnUrl"
               asp-route-email="@Model.EmailInput?.Email"
+              asp-route-subscribeToNewsletter="@(Model.EmailInput?.SubscribeToNewsletter ?? false)"
               method="post">
 
             <div class="mb-3">

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/SetVerifiedEmail.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/SetVerifiedEmail.cshtml.cs
@@ -29,6 +29,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
 {
     public class SetVerifiedEmailModel(
         IEmailSender emailSender,
+        INewsletterService newsletterService,
         IClientStore clientStore,
         ISsoDbContext context,
         IIdentityServerInteractionService idServerInteractionService,
@@ -48,6 +49,9 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             [Display(Name = "Email (optional)")]
             [Required]
             public string Email { get; set; } = null!;
+
+            [Display(Name = "Subscribe to our newsletter")]
+            public bool SubscribeToNewsletter { get; set; }
         }
 
         // Properties.
@@ -62,8 +66,8 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         public string? ReturnUrl { get; private set; }
 
         // Methods.
-        public async Task OnGetAsync(string? email, bool isCodeSent, string? returnUrl) =>
-            await InitializeAsync(email, isCodeSent, returnUrl);
+        public async Task OnGetAsync(string? email, bool subscribeToNewsletter, bool isCodeSent, string? returnUrl) =>
+            await InitializeAsync(email, subscribeToNewsletter, isCodeSent, returnUrl);
 
         public async Task<IActionResult> OnGetSkipAsync(string? returnUrl) =>
             await ProceedAsync(returnUrl);
@@ -83,7 +87,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
 
             if (ModelState.ErrorCount > 0)
             {
-                await InitializeAsync(EmailInput.Email, false, returnUrl);
+                await InitializeAsync(EmailInput.Email, EmailInput.SubscribeToNewsletter, false, returnUrl);
                 return Page();
             }
 
@@ -102,11 +106,11 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                 emailBody);
 
             // Return page.
-            await InitializeAsync(EmailInput.Email, true, returnUrl);
+            await InitializeAsync(EmailInput.Email, EmailInput.SubscribeToNewsletter, true, returnUrl);
             return Page();
         }
 
-        public async Task<IActionResult> OnPostConfirmCodeAsync(string email, string? returnUrl)
+        public async Task<IActionResult> OnPostConfirmCodeAsync(string email, bool subscribeToNewsletter, string? returnUrl)
         {
             // Validate model.
             ModelState.Clear();
@@ -121,7 +125,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
 
             if (ModelState.ErrorCount > 0)
             {
-                await InitializeAsync(email, true, returnUrl);
+                await InitializeAsync(email, subscribeToNewsletter, true, returnUrl);
                 return Page();
             }
 
@@ -129,14 +133,20 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             user.SetEmail(email);
             await context.SaveChangesAsync();
 
+            // Forward the verified contact to the newsletter service (best-effort, single opt-in).
+            // The email in the SSO db is never used for marketing: the newsletter service owns both the
+            // allowed list and the consent record (opt-in timestamp, source), so nothing is stored here.
+            if (subscribeToNewsletter)
+                await newsletterService.SubscribeEmailAsync(email, NewsletterSubscriptionSource.Registration);
+
             return await ProceedAsync(returnUrl);
         }
 
         // Helpers.
-        private async Task InitializeAsync(string? email, bool isCodeSent, string? returnUrl)
+        private async Task InitializeAsync(string? email, bool subscribeToNewsletter, bool isCodeSent, string? returnUrl)
         {
             if (email is not null)
-                EmailInput = new EmailInputModel { Email = email };
+                EmailInput = new EmailInputModel { Email = email, SubscribeToNewsletter = subscribeToNewsletter };
 
             var user = await userManager.GetUserAsync(User);
             IsWeb3 = user is UserWeb3;

--- a/src/EthernaSSO/Program.cs
+++ b/src/EthernaSSO/Program.cs
@@ -470,6 +470,7 @@ namespace Etherna.SSOServer
             // Configure setting.
             services.Configure<ApplicationOptions>(config.GetSection("Application") ?? throw new ServiceConfigurationException());
             services.Configure<EmailOptions>(config.GetSection("Email") ?? throw new ServiceConfigurationException());
+            services.Configure<NewsletterOptions>(config.GetSection("Newsletter") ?? throw new ServiceConfigurationException());
             services.Configure<SsoDbSeedSettings>(config.GetSection("DbSeed") ?? throw new ServiceConfigurationException());
             
             // Configure api handler.


### PR DESCRIPTION
Add an optional, opt-in newsletter subscription backed by an external newsletter service (Mailchimp), shipped disabled by default.

- New INewsletterService/NewsletterService using MailChimp.Net, config-gated via Newsletter:CurrentService with a no-op FakeService default; single opt-in since the email is already verified by the SSO.
- Opt-in offered during email verification (SetVerifiedEmail) and from the account email settings (Manage/Email); on the account page the subscribe button is shown only when the contact is not already subscribed.
- The subscription source is passed as a semantic enum and mapped to the contact tag inside the service.
- No marketing or consent state is stored in the SSO: the newsletter service owns the allowed list and the consent record.
- Subscription is idempotent (add-or-update) and best-effort: failures are logged and never block account registration.