### PR TITLE
Add legal documents acceptance on registration (ESSO-256)

### DIFF
--- a/src/EthernaSSO.Domain/Models/UserAgg/LegalAcceptance.cs
+++ b/src/EthernaSSO.Domain/Models/UserAgg/LegalAcceptance.cs
@@ -1,0 +1,61 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Etherna.SSOServer.Domain.Models.UserAgg
+{
+    /// <summary>
+    /// The proof that a user accepted a specific version of a legal document at a given moment.
+    /// Kept as an immutable, append-only record to satisfy the accountability principle
+    /// (GDPR art. 7(1) / Swiss nFADP): we must be able to demonstrate what was accepted and when.
+    /// </summary>
+    public class LegalAcceptance : ModelBase
+    {
+        // Constructors.
+        public LegalAcceptance(
+            LegalDocumentType documentType,
+            string version,
+            DateTime acceptanceDateTime)
+        {
+            if (string.IsNullOrWhiteSpace(version))
+                throw new ArgumentException("Version can't be empty", nameof(version));
+
+            AcceptanceDateTime = acceptanceDateTime;
+            DocumentType = documentType;
+            Version = version;
+        }
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+        protected LegalAcceptance() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+        // Properties.
+        public virtual DateTime AcceptanceDateTime { get; protected set; }
+        public virtual LegalDocumentType DocumentType { get; protected set; }
+        public virtual string Version { get; protected set; }
+
+        // Methods.
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj is not LegalAcceptance other) return false;
+            return AcceptanceDateTime == other.AcceptanceDateTime &&
+                DocumentType == other.DocumentType &&
+                Version == other.Version;
+        }
+
+        public override int GetHashCode() =>
+            HashCode.Combine(AcceptanceDateTime, DocumentType, Version);
+    }
+}

--- a/src/EthernaSSO.Domain/Models/UserAgg/LegalDocumentType.cs
+++ b/src/EthernaSSO.Domain/Models/UserAgg/LegalDocumentType.cs
@@ -1,0 +1,26 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+namespace Etherna.SSOServer.Domain.Models.UserAgg
+{
+    /// <summary>
+    /// A legal document a user can be required to accept. Persisted by name (not by ordinal),
+    /// so members can be reordered without altering the meaning of stored acceptance records.
+    /// </summary>
+    public enum LegalDocumentType
+    {
+        PrivacyPolicy,
+        TermsOfService
+    }
+}

--- a/src/EthernaSSO.Domain/Models/UserBase.cs
+++ b/src/EthernaSSO.Domain/Models/UserBase.cs
@@ -40,6 +40,7 @@ namespace Etherna.SSOServer.Domain.Models
         ];
 
         // Fields.
+        private List<LegalAcceptance> _acceptedLegalDocuments = [];
         private readonly List<UserClaim> _customClaims = new();
         private List<EthAddress> _etherPreviousAddresses = new();
         private List<Role> _roles = new();
@@ -64,6 +65,16 @@ namespace Etherna.SSOServer.Domain.Models
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
         // Properties.
+        /// <summary>
+        /// Append-only history of the legal documents this user accepted (which document, which
+        /// version, and when). Kept as our own proof of consent for GDPR/nFADP accountability.
+        /// </summary>
+        [PersonalData]
+        public virtual IEnumerable<LegalAcceptance> AcceptedLegalDocuments
+        {
+            get => _acceptedLegalDocuments;
+            protected set => _acceptedLegalDocuments = [..value ?? []];
+        }
         public virtual IEnumerable<UserClaim> Claims
         {
             get => DefaultClaims.Union(_customClaims);
@@ -158,6 +169,16 @@ namespace Etherna.SSOServer.Domain.Models
 
             _customClaims.Add(claim);
             return true;
+        }
+
+        [PropertyAlterer(nameof(AcceptedLegalDocuments))]
+        public virtual void AddLegalAcceptances(IEnumerable<LegalAcceptance> acceptances)
+        {
+            ArgumentNullException.ThrowIfNull(acceptances);
+
+            //append, never replace: the history must be preserved for accountability
+            foreach (var acceptance in acceptances)
+                _acceptedLegalDocuments.Add(acceptance);
         }
 
         [PropertyAlterer(nameof(Roles))]

--- a/src/EthernaSSO.Persistence/ModelMaps/Sso/LegalAcceptanceMap.cs
+++ b/src/EthernaSSO.Persistence/ModelMaps/Sso/LegalAcceptanceMap.cs
@@ -1,0 +1,28 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongODM.Core;
+using Etherna.MongODM.Core.Serialization;
+using Etherna.SSOServer.Domain.Models.UserAgg;
+
+namespace Etherna.SSOServer.Persistence.ModelMaps.Sso
+{
+    internal sealed class LegalAcceptanceMap : IModelMapsCollector
+    {
+        public void Register(IDbContext dbContext)
+        {
+            dbContext.MapRegistry.AddModelMap<LegalAcceptance>("ff4b1d15-f6d6-48fa-86b8-3087cf75018d");
+        }
+    }
+}

--- a/src/EthernaSSO.Services/Domain/ILegalService.cs
+++ b/src/EthernaSSO.Services/Domain/ILegalService.cs
@@ -1,0 +1,40 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SSOServer.Domain.Models.UserAgg;
+using System.Collections.Generic;
+
+namespace Etherna.SSOServer.Services.Domain
+{
+    /// <summary>
+    /// A legal document the user must accept to register, resolved to its currently published
+    /// version and public URL.
+    /// </summary>
+    public sealed record LegalDocument(LegalDocumentType Type, string Version, string Url);
+
+    public interface ILegalService
+    {
+        /// <summary>
+        /// The legal documents that must be accepted to create an account, in display order.
+        /// </summary>
+        IReadOnlyList<LegalDocument> RequiredDocuments { get; }
+
+        /// <summary>
+        /// Build an acceptance record for every required document, stamped at the current instant
+        /// with the version currently published. The returned records are the proof of consent to
+        /// persist together with the new user.
+        /// </summary>
+        IEnumerable<LegalAcceptance> BuildAcceptancesForRequiredDocuments();
+    }
+}

--- a/src/EthernaSSO.Services/Domain/IUserService.cs
+++ b/src/EthernaSSO.Services/Domain/IUserService.cs
@@ -34,7 +34,8 @@ namespace Etherna.SSOServer.Services.Domain
         Task<(IEnumerable<(string key, string msg)> errors, UserWeb2? user)> RegisterWeb2UserAsync(
             string username,
             string password,
-            string? invitationCode);
+            string? invitationCode,
+            IEnumerable<LegalAcceptance> legalAcceptances);
 
         Task<(IEnumerable<(string key, string msg)> errors, UserWeb2? user)> RegisterWeb2UserByAdminAsync(
             string username,
@@ -49,7 +50,8 @@ namespace Etherna.SSOServer.Services.Domain
         Task<(IEnumerable<(string key, string msg)> errors, UserWeb3? user)> RegisterWeb3UserAsync(
             string username,
             EthAddress etherAddress,
-            string? invitationCode);
+            string? invitationCode,
+            IEnumerable<LegalAcceptance> legalAcceptances);
 
         Task<PaginatedEnumerable<UserBase>> SearchPaginatedUsersByQueryAsync<TOrderKey>(
             string? query,

--- a/src/EthernaSSO.Services/Domain/LegalService.cs
+++ b/src/EthernaSSO.Services/Domain/LegalService.cs
@@ -1,0 +1,46 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SSOServer.Domain.Models.UserAgg;
+using Etherna.SSOServer.Services.Options;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Etherna.SSOServer.Services.Domain
+{
+    internal sealed class LegalService(IOptions<LegalOptions> options) : ILegalService
+    {
+        // Fields.
+        private readonly LegalOptions options = options.Value;
+
+        // Properties.
+        public IReadOnlyList<LegalDocument> RequiredDocuments =>
+        [
+            new(LegalDocumentType.TermsOfService, options.TermsOfService.Version, options.TermsOfService.Url),
+            new(LegalDocumentType.PrivacyPolicy, options.PrivacyPolicy.Version, options.PrivacyPolicy.Url)
+        ];
+
+        // Methods.
+        public IEnumerable<LegalAcceptance> BuildAcceptancesForRequiredDocuments()
+        {
+            // A single timestamp for the whole consent action, captured once at acceptance time.
+            var acceptanceDateTime = DateTime.UtcNow;
+            return RequiredDocuments
+                .Select(d => new LegalAcceptance(d.Type, d.Version, acceptanceDateTime))
+                .ToList();
+        }
+    }
+}

--- a/src/EthernaSSO.Services/Domain/UserService.cs
+++ b/src/EthernaSSO.Services/Domain/UserService.cs
@@ -75,7 +75,8 @@ namespace Etherna.SSOServer.Services.Domain
         public Task<(IEnumerable<(string key, string msg)> errors, UserWeb2? user)> RegisterWeb2UserAsync(
             string username,
             string password,
-            string? invitationCode) =>
+            string? invitationCode,
+            IEnumerable<LegalAcceptance> legalAcceptances) =>
             RegisterUserHelperAsync(
                 username,
                 invitationCode,
@@ -91,6 +92,7 @@ namespace Etherna.SSOServer.Services.Domain
 
                     // Create user.
                     var user = new UserWeb2(username, invitedByUser, invitedByAdmin, etherPrivateKey, sharedInfo);
+                    user.AddLegalAcceptances(legalAcceptances);
                     var result = await UserManager.CreateAsync(user, password);
 
                     return (user, result);
@@ -140,7 +142,8 @@ namespace Etherna.SSOServer.Services.Domain
         public Task<(IEnumerable<(string key, string msg)> errors, UserWeb3? user)> RegisterWeb3UserAsync(
             string username,
             EthAddress etherAddress,
-            string? invitationCode) =>
+            string? invitationCode,
+            IEnumerable<LegalAcceptance> legalAcceptances) =>
             RegisterUserHelperAsync(
                 username,
                 invitationCode,
@@ -152,6 +155,7 @@ namespace Etherna.SSOServer.Services.Domain
 
                     // Create user.
                     var user = new UserWeb3(username, invitedByUser, invitedByAdmin, sharedInfo);
+                    user.AddLegalAcceptances(legalAcceptances);
                     var result = await UserManager.CreateAsync(user);
                     return (user, result);
                 });

--- a/src/EthernaSSO.Services/Options/LegalOptions.cs
+++ b/src/EthernaSSO.Services/Options/LegalOptions.cs
@@ -1,0 +1,36 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+namespace Etherna.SSOServer.Services.Options
+{
+    public sealed class LegalOptions
+    {
+        // Types.
+        public sealed class DocumentOptions
+        {
+            public string Url { get; set; } = null!;
+
+            /// <summary>
+            /// Identifier of the currently published revision of the document (e.g. an ISO date or a
+            /// semantic version). It is stored verbatim in each acceptance record, so it must change
+            /// whenever the document text materially changes.
+            /// </summary>
+            public string Version { get; set; } = null!;
+        }
+
+        // Properties.
+        public DocumentOptions PrivacyPolicy { get; set; } = new();
+        public DocumentOptions TermsOfService { get; set; } = new();
+    }
+}

--- a/src/EthernaSSO.Services/ServiceCollectionExtensions.cs
+++ b/src/EthernaSSO.Services/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ namespace Etherna.SSOServer.Services
             //domain
             services.AddScoped<IEmailSender, EmailSender>();
             services.AddScoped<IFido2Service, Fido2Service>();
+            services.AddScoped<ILegalService, LegalService>();
             services.AddScoped<INewsletterService, NewsletterService>();
             services.AddScoped<IRazorViewRenderer, RazorViewRenderer>();
             services.AddScoped<IUserService, UserService>();

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Legal.cshtml
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Legal.cshtml
@@ -1,0 +1,58 @@
+@page
+@model LegalModel
+@{
+    ViewData["Title"] = "Legal";
+    ViewData["ActivePage"] = ManageNavPages.Legal;
+}
+
+<h4>@ViewData["Title"]</h4>
+
+<div class="row">
+    <div class="col-md-8">
+        <p>The record of the legal documents you accepted, and when.</p>
+
+        @if (Model.AcceptedDocuments.Count == 0)
+        {
+            <p class="text-muted">No legal acceptances are recorded for your account.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Document</th>
+                            <th>Accepted version</th>
+                            <th>Accepted on (UTC)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var doc in Model.AcceptedDocuments)
+                        {
+                            <tr>
+                                <td class="align-middle">
+                                    @if (doc.CurrentUrl is not null)
+                                    {
+                                        <a href="@doc.CurrentUrl" target="_blank" rel="noopener noreferrer">@doc.Name</a>
+                                    }
+                                    else
+                                    {
+                                        @doc.Name
+                                    }
+                                </td>
+                                <td class="align-middle">
+                                    @doc.Version
+                                    @if (!doc.IsCurrentVersion)
+                                    {
+                                        <span class="badge bg-secondary ms-1" title="A newer version has since been published">superseded</span>
+                                    }
+                                </td>
+                                <td class="align-middle">@doc.AcceptanceDateTime.ToString("dd/MM/yyyy HH:mm:ss")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Legal.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Legal.cshtml.cs
@@ -1,0 +1,75 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SSOServer.Domain.Models;
+using Etherna.SSOServer.Domain.Models.UserAgg;
+using Etherna.SSOServer.Services.Domain;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
+{
+    public class LegalModel(
+        ILegalService legalService,
+        UserManager<UserBase> userManager)
+        : PageModel
+    {
+        // Models.
+        public sealed record AcceptedDocument(
+            string Name,
+            string Version,
+            DateTime AcceptanceDateTime,
+            string? CurrentUrl,
+            bool IsCurrentVersion);
+
+        // Properties.
+        public IReadOnlyList<AcceptedDocument> AcceptedDocuments { get; private set; } = [];
+
+        // Methods.
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var user = await userManager.GetUserAsync(User);
+            if (user is null)
+                return NotFound($"Unable to load user with ID '{userManager.GetUserId(User)}'.");
+
+            var requiredDocuments = legalService.RequiredDocuments;
+            AcceptedDocuments = user.AcceptedLegalDocuments
+                .OrderByDescending(a => a.AcceptanceDateTime)
+                .Select(a =>
+                {
+                    var current = requiredDocuments.FirstOrDefault(d => d.Type == a.DocumentType);
+                    var name = a.DocumentType switch
+                    {
+                        LegalDocumentType.PrivacyPolicy => "Privacy Policy",
+                        LegalDocumentType.TermsOfService => "Terms of Service",
+                        _ => a.DocumentType.ToString()
+                    };
+                    return new AcceptedDocument(
+                        name,
+                        a.Version,
+                        a.AcceptanceDateTime,
+                        current?.Url,
+                        current is not null && current.Version == a.Version);
+                })
+                .ToList();
+
+            return Page();
+        }
+    }
+}

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
@@ -22,6 +22,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
         // Properties.
         public static string Index => "Index";
         public static string Developer => "Developer";
+        public static string Legal => "Legal";
         public static string Email => "Email";
         public static string ChangePassword => "ChangePassword";
         public static string DownloadPersonalData => "DownloadPersonalData";
@@ -43,6 +44,13 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
             ArgumentNullException.ThrowIfNull(viewContext);
 
             return PageNavClass(viewContext, Developer);
+        }
+
+        public static string? LegalNavClass(ViewContext viewContext)
+        {
+            ArgumentNullException.ThrowIfNull(viewContext);
+
+            return PageNavClass(viewContext, Legal);
         }
 
         public static string? EmailNavClass(ViewContext viewContext)

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
@@ -18,4 +18,5 @@
     }
     <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="/Account/Manage/PersonalData" asp-area="Identity">Personal data</a></li>
     <li class="nav-item"><a class="nav-link @ManageNavPages.DeveloperNavClass(ViewContext)" id="developer" asp-page="/Account/Manage/Developer/Index" asp-area="Identity">Developer</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.LegalNavClass(ViewContext)" id="legal" asp-page="/Account/Manage/Legal" asp-area="Identity">Legal</a></li>
 </ul>

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Register.cshtml
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Register.cshtml
@@ -53,6 +53,20 @@
                        asp-page="/Index">Click here to request an Alpha Pass!</a>
                 </p>
             </div>
+            <div class="mb-3 form-check">
+                <input asp-for="Input.AcceptTermsOfService" class="form-check-input" />
+                <label asp-for="Input.AcceptTermsOfService" class="form-check-label">
+                    I accept the <a href="@Model.TermsOfServiceUrl" target="_blank" rel="noopener noreferrer">Terms of Service</a>.
+                </label>
+                <span asp-validation-for="Input.AcceptTermsOfService" class="text-danger d-block"></span>
+            </div>
+            <div class="mb-3 form-check">
+                <input asp-for="Input.AcceptPrivacyPolicy" class="form-check-input" />
+                <label asp-for="Input.AcceptPrivacyPolicy" class="form-check-label">
+                    I have read the <a href="@Model.PrivacyPolicyUrl" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+                </label>
+                <span asp-validation-for="Input.AcceptPrivacyPolicy" class="text-danger d-block"></span>
+            </div>
             <div class="mb-3">
                 <button type="submit" class="btn btn-primary">Register</button>
             </div>

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -15,9 +15,11 @@
 using Duende.IdentityServer.Services;
 using Etherna.DomainEvents;
 using Etherna.SSOServer.Configs.Metrics;
+using Etherna.SSOServer.Configs.Validation;
 using Etherna.SSOServer.Domain.Events;
 using Etherna.SSOServer.Domain.Helpers;
 using Etherna.SSOServer.Domain.Models;
+using Etherna.SSOServer.Domain.Models.UserAgg;
 using Etherna.SSOServer.Services.Domain;
 using Etherna.SSOServer.Services.Extensions;
 using Etherna.SSOServer.Services.Options;
@@ -31,6 +33,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Etherna.SSOServer.Areas.Identity.Pages.Account
@@ -42,6 +45,14 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         public class InputModel : IValidatableObject
         {
             // Properties.
+            [Display(Name = "I have read the Privacy Policy")]
+            [MustBeTrue(ErrorMessage = "You must confirm you have read the Privacy Policy to register.")]
+            public bool AcceptPrivacyPolicy { get; set; }
+
+            [Display(Name = "I accept the Terms of Service")]
+            [MustBeTrue(ErrorMessage = "You must accept the Terms of Service to register.")]
+            public bool AcceptTermsOfService { get; set; }
+
             [Required]
             [RegularExpression(UsernameHelper.UsernameRegex, ErrorMessage = UsernameHelper.UsernameValidationErrorMessage)]
             [Display(Name = "Username")]
@@ -80,6 +91,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         private readonly ApplicationOptions applicationOptions;
         private readonly IEventDispatcher eventDispatcher;
         private readonly IIdentityServerInteractionService idServerInteractService;
+        private readonly ILegalService legalService;
         private readonly ILogger<RegisterModel> logger;
         private readonly SignInManager<UserBase> signInManager;
         private readonly IUserService userService;
@@ -89,6 +101,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             IOptions<ApplicationOptions> applicationSettings,
             IEventDispatcher eventDispatcher,
             IIdentityServerInteractionService idServerInteractService,
+            ILegalService legalService,
             ILogger<RegisterModel> logger,
             SignInManager<UserBase> signInManager,
             IUserService userService)
@@ -98,6 +111,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             this.applicationOptions = applicationSettings.Value;
             this.eventDispatcher = eventDispatcher;
             this.idServerInteractService = idServerInteractService;
+            this.legalService = legalService;
             this.logger = logger;
             this.signInManager = signInManager;
             this.userService = userService;
@@ -108,7 +122,9 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         public InputModel Input { get; set; } = null!;
 
         public bool IsInvitationRequired { get; private set; }
+        public string PrivacyPolicyUrl { get; private set; } = null!;
         public string? ReturnUrl { get; private set; }
+        public string TermsOfServiceUrl { get; private set; } = null!;
         public Web3LoginPartialModel Web3LoginPartialModel { get; private set; } = null!;
 
         // Methods.
@@ -126,7 +142,8 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             var (errors, user) = await userService.RegisterWeb2UserAsync(
                 Input.Username,
                 Input.Password,
-                Input.InvitationCode);
+                Input.InvitationCode,
+                legalService.BuildAcceptancesForRequiredDocuments());
 
             // Post-registration actions.
             if (user is not null)
@@ -164,7 +181,9 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             Input ??= new InputModel();
             Input.InvitationCode ??= invitationCode;
             IsInvitationRequired = applicationOptions.RequireInvitation;
+            PrivacyPolicyUrl = legalService.RequiredDocuments.First(d => d.Type == LegalDocumentType.PrivacyPolicy).Url;
             ReturnUrl = returnUrl ?? Url.Content("~/");
+            TermsOfServiceUrl = legalService.RequiredDocuments.First(d => d.Type == LegalDocumentType.TermsOfService).Url;
 
             //init partial view models
             Web3LoginPartialModel = new Web3LoginPartialModel()

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml
@@ -42,6 +42,20 @@
                        asp-page="/Index">Click here to request an Alpha Pass!</a>
                 </p>
             </div>
+            <div class="mb-3 form-check">
+                <input asp-for="Input.AcceptTermsOfService" class="form-check-input" />
+                <label asp-for="Input.AcceptTermsOfService" class="form-check-label">
+                    I accept the <a href="@Model.TermsOfServiceUrl" target="_blank" rel="noopener noreferrer">Terms of Service</a>.
+                </label>
+                <span asp-validation-for="Input.AcceptTermsOfService" class="text-danger d-block"></span>
+            </div>
+            <div class="mb-3 form-check">
+                <input asp-for="Input.AcceptPrivacyPolicy" class="form-check-input" />
+                <label asp-for="Input.AcceptPrivacyPolicy" class="form-check-label">
+                    I have read the <a href="@Model.PrivacyPolicyUrl" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+                </label>
+                <span asp-validation-for="Input.AcceptPrivacyPolicy" class="text-danger d-block"></span>
+            </div>
             <button type="submit" class="btn btn-primary">Register</button>
         </form>
     </div>

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml.cs
@@ -17,10 +17,12 @@ using Duende.IdentityServer.Stores;
 using Etherna.DomainEvents;
 using Etherna.MongoDB.Driver;
 using Etherna.SSOServer.Configs.Metrics;
+using Etherna.SSOServer.Configs.Validation;
 using Etherna.SSOServer.Domain;
 using Etherna.SSOServer.Domain.Events;
 using Etherna.SSOServer.Domain.Helpers;
 using Etherna.SSOServer.Domain.Models;
+using Etherna.SSOServer.Domain.Models.UserAgg;
 using Etherna.SSOServer.Services.Domain;
 using Etherna.SSOServer.Services.Extensions;
 using Etherna.SSOServer.Services.Options;
@@ -32,6 +34,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Etherna.SSOServer.Areas.Identity.Pages.Account
@@ -42,6 +45,14 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         public class InputModel : IValidatableObject
         {
             // Properties.
+            [Display(Name = "I have read the Privacy Policy")]
+            [MustBeTrue(ErrorMessage = "You must confirm you have read the Privacy Policy to register.")]
+            public bool AcceptPrivacyPolicy { get; set; }
+
+            [Display(Name = "I accept the Terms of Service")]
+            [MustBeTrue(ErrorMessage = "You must accept the Terms of Service to register.")]
+            public bool AcceptTermsOfService { get; set; }
+
             [Display(Name = "Invitation code")]
             public string? InvitationCode { get; set; }
 
@@ -60,7 +71,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
                 {
                     yield return new ValidationResult(
                         "Invitation code is required",
-                        new[] { nameof(InvitationCode) });
+                        [nameof(InvitationCode)]);
                 }
             }
         }
@@ -69,6 +80,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         private readonly ApplicationOptions applicationOptions;
         private readonly IEventDispatcher eventDispatcher;
         private readonly IIdentityServerInteractionService idServerInteractionService;
+        private readonly ILegalService legalService;
         private readonly ILogger<Web3LoginModel> logger;
         private readonly SignInManager<UserBase> signInManager;
         private readonly ISsoDbContext ssoDbContext;
@@ -82,6 +94,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             IClientStore clientStore,
             IEventDispatcher eventDispatcher,
             IIdentityServerInteractionService idServerInteractionService,
+            ILegalService legalService,
             ILogger<Web3LoginModel> logger,
             SignInManager<UserBase> signInManager,
             ISsoDbContext ssoDbContext,
@@ -95,6 +108,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             this.applicationOptions = applicationSettings.Value;
             this.eventDispatcher = eventDispatcher;
             this.idServerInteractionService = idServerInteractionService;
+            this.legalService = legalService;
             this.logger = logger;
             this.signInManager = signInManager;
             this.ssoDbContext = ssoDbContext;
@@ -113,8 +127,10 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         public bool DuplicateUsername { get; private set; }
         public EthAddress? EtherAddress { get; private set; }
         public bool IsInvitationRequired { get; private set; }
+        public string PrivacyPolicyUrl { get; private set; } = null!;
         public string? ReturnUrl { get; private set; }
         public string? Signature { get; private set; }
+        public string TermsOfServiceUrl { get; private set; } = null!;
 
         // Methods.
         public IActionResult OnGet() =>
@@ -217,7 +233,8 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             var (errors, user) = await userService.RegisterWeb3UserAsync(
                 Input.Username,
                 etherAddress,
-                Input.InvitationCode);
+                Input.InvitationCode,
+                legalService.BuildAcceptancesForRequiredDocuments());
 
             // Post-registration actions.
             if (user is not null)
@@ -257,8 +274,10 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         {
             EtherAddress = etherAddress;
             IsInvitationRequired = applicationOptions.RequireInvitation;
+            PrivacyPolicyUrl = legalService.RequiredDocuments.First(d => d.Type == LegalDocumentType.PrivacyPolicy).Url;
             ReturnUrl = returnUrl ?? Url.Content("~/");
             Signature = signature;
+            TermsOfServiceUrl = legalService.RequiredDocuments.First(d => d.Type == LegalDocumentType.TermsOfService).Url;
         }
     }
 }

--- a/src/EthernaSSO/Configs/Validation/MustBeTrueAttribute.cs
+++ b/src/EthernaSSO/Configs/Validation/MustBeTrueAttribute.cs
@@ -1,0 +1,53 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Etherna.SSOServer.Configs.Validation
+{
+    /// <summary>
+    /// Requires a boolean value to be true, e.g. a mandatory acceptance checkbox.
+    /// Validation runs both server-side and client-side (without a page reload). The built-in
+    /// unobtrusive "required" rule intentionally skips checkboxes, so this attribute emits a dedicated
+    /// "mustbetrue" rule whose client adapter is registered in <c>Static/js/site.js</c>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class MustBeTrueAttribute : ValidationAttribute, IClientModelValidator
+    {
+        // Consts.
+        //must match the adapter/method name registered in Static/js/site.js
+        public const string RuleName = "mustbetrue";
+
+        // Methods.
+        public void AddValidation(ClientModelValidationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            MergeAttribute(context.Attributes, "data-val", "true");
+            MergeAttribute(context.Attributes, $"data-val-{RuleName}", FormatErrorMessage(context.ModelMetadata.GetDisplayName()));
+        }
+
+        public override bool IsValid(object? value) => value is true;
+
+        // Helpers.
+        private static void MergeAttribute(IDictionary<string, string> attributes, string key, string value)
+        {
+            if (!attributes.ContainsKey(key))
+                attributes.Add(key, value);
+        }
+    }
+}

--- a/src/EthernaSSO/Program.cs
+++ b/src/EthernaSSO/Program.cs
@@ -470,6 +470,7 @@ namespace Etherna.SSOServer
             // Configure setting.
             services.Configure<ApplicationOptions>(config.GetSection("Application") ?? throw new ServiceConfigurationException());
             services.Configure<EmailOptions>(config.GetSection("Email") ?? throw new ServiceConfigurationException());
+            services.Configure<LegalOptions>(config.GetSection("Legal") ?? throw new ServiceConfigurationException());
             services.Configure<NewsletterOptions>(config.GetSection("Newsletter") ?? throw new ServiceConfigurationException());
             services.Configure<SsoDbSeedSettings>(config.GetSection("DbSeed") ?? throw new ServiceConfigurationException());
             

--- a/src/EthernaSSO/Static/js/site.js
+++ b/src/EthernaSSO/Static/js/site.js
@@ -4,6 +4,14 @@ import "jquery-validation"
 import "jquery-validation-unobtrusive"
 import datepickerFactory from "jquery-datepicker"
 
+// Client adapter for the [MustBeTrue] attribute (mandatory acceptance checkboxes).
+// The built-in unobtrusive "required" adapter intentionally skips checkboxes, so a dedicated
+// "mustbetrue" rule is needed to validate them in page, without a reload.
+$.validator.addMethod("mustbetrue", function (value, element) {
+  return element.type === "checkbox" ? element.checked : value === "true" || value === true
+})
+$.validator.unobtrusive.adapters.addBool("mustbetrue")
+
 // jQuery date picker
 datepickerFactory($)
 

--- a/src/EthernaSSO/appsettings.json
+++ b/src/EthernaSSO/appsettings.json
@@ -20,6 +20,17 @@
     "TimestampDriftTolerance": 300000
   },
 
+  "Legal": {
+    "PrivacyPolicy": {
+      "Url": "https://info.etherna.io/privacy-policy",
+      "Version": "2026-06-25"
+    },
+    "TermsOfService": {
+      "Url": "https://info.etherna.io/terms-of-service",
+      "Version": "2026-06-25"
+    }
+  },
+
   "IdServer": {
     "Clients": {
       "ApiKey": {

--- a/test/EthernaSSO.Domain.Tests/Models/UserAgg/LegalAcceptanceTest.cs
+++ b/test/EthernaSSO.Domain.Tests/Models/UserAgg/LegalAcceptanceTest.cs
@@ -1,0 +1,75 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Etherna.SSOServer.Domain.Models.UserAgg
+{
+    [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method naming convention.")]
+    public class LegalAcceptanceTest
+    {
+        [Fact]
+        public void Constructor_WithValidArguments_SetsProperties()
+        {
+            // Arrange.
+            var acceptanceDateTime = new DateTime(2026, 06, 25, 10, 30, 00, DateTimeKind.Utc);
+
+            // Action.
+            var acceptance = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", acceptanceDateTime);
+
+            // Assert.
+            Assert.Equal(LegalDocumentType.TermsOfService, acceptance.DocumentType);
+            Assert.Equal("2026-06-25", acceptance.Version);
+            Assert.Equal(acceptanceDateTime, acceptance.AcceptanceDateTime);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Constructor_WithEmptyVersion_ThrowsArgumentException(string? version)
+        {
+            // Assert.
+            Assert.Throws<ArgumentException>(() =>
+                new LegalAcceptance(LegalDocumentType.PrivacyPolicy, version!, DateTime.UtcNow));
+        }
+
+        [Fact]
+        public void Equals_WithSameValues_ReturnsTrue()
+        {
+            // Arrange.
+            var acceptanceDateTime = new DateTime(2026, 06, 25, 10, 30, 00, DateTimeKind.Utc);
+            var a = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", acceptanceDateTime);
+            var b = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", acceptanceDateTime);
+
+            // Assert.
+            Assert.Equal(a, b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_WithDifferentVersion_ReturnsFalse()
+        {
+            // Arrange.
+            var acceptanceDateTime = new DateTime(2026, 06, 25, 10, 30, 00, DateTimeKind.Utc);
+            var a = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", acceptanceDateTime);
+            var b = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-01-01", acceptanceDateTime);
+
+            // Assert.
+            Assert.NotEqual(a, b);
+        }
+    }
+}

--- a/test/EthernaSSO.Domain.Tests/Models/UserAgg/UserBaseTest.cs
+++ b/test/EthernaSSO.Domain.Tests/Models/UserAgg/UserBaseTest.cs
@@ -75,6 +75,50 @@ namespace Etherna.SSOServer.Domain.Models.UserAgg
         }
 
         [Fact]
+        public void AddLegalAcceptances_WithAcceptances_AppendsRecords()
+        {
+            // Arrange.
+            var user = CreateUser();
+            var acceptances = new[]
+            {
+                new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", new DateTime(2026, 06, 25, 10, 0, 0, DateTimeKind.Utc)),
+                new LegalAcceptance(LegalDocumentType.PrivacyPolicy, "2026-06-25", new DateTime(2026, 06, 25, 10, 0, 0, DateTimeKind.Utc))
+            };
+
+            // Action.
+            user.AddLegalAcceptances(acceptances);
+
+            // Assert.
+            Assert.Equal(acceptances, user.AcceptedLegalDocuments);
+        }
+
+        [Fact]
+        public void AddLegalAcceptances_CalledTwice_PreservesPreviousHistory()
+        {
+            // Arrange.
+            var user = CreateUser();
+            var first = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-01-01", new DateTime(2026, 01, 01, 0, 0, 0, DateTimeKind.Utc));
+            var second = new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", new DateTime(2026, 06, 25, 0, 0, 0, DateTimeKind.Utc));
+            user.AddLegalAcceptances([first]);
+
+            // Action.
+            user.AddLegalAcceptances([second]);
+
+            // Assert.
+            Assert.Equal([first, second], user.AcceptedLegalDocuments);
+        }
+
+        [Fact]
+        public void AddLegalAcceptances_WithNull_ThrowsArgumentNullException()
+        {
+            // Arrange.
+            var user = CreateUser();
+
+            // Assert.
+            Assert.Throws<ArgumentNullException>(() => user.AddLegalAcceptances(null!));
+        }
+
+        [Fact]
         public void AddRole_WithNewRole_AddsRoleAndReturnsTrue()
         {
             // Arrange.

--- a/test/EthernaSSO.Persistence.Tests/ModelMaps/SsoDbContextDeserializationTest.cs
+++ b/test/EthernaSSO.Persistence.Tests/ModelMaps/SsoDbContextDeserializationTest.cs
@@ -480,7 +480,21 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
                             ""_id"" : ObjectId(""6a317235d33d390f7d1e350e""),                                                                                                                                                                     
                             ""_m"" : ""c54bb1fe-a7e2-4069-b91c-1065b16ca4da"",                                                                                                                                                                    
                             ""_t"" : ""UserWeb2"",                                                                                                                                                                                                
-                            ""CreationDateTime"" : ISODate(""2026-06-16T17:56:37.411+02:00""),                                                                                                                                                    
+                            ""CreationDateTime"" : ISODate(""2026-06-16T17:56:37.411+02:00""),   
+                            ""AcceptedLegalDocuments"" : [
+                                {
+                                    ""_m"" : ""ff4b1d15-f6d6-48fa-86b8-3087cf75018d"",
+                                    ""AcceptanceDateTime"" : ISODate(""2026-06-25T10:00:00.000+00:00""),
+                                    ""DocumentType"" : ""TermsOfService"",
+                                    ""Version"" : ""2026-06-25""
+                                },
+                                {
+                                    ""_m"" : ""ff4b1d15-f6d6-48fa-86b8-3087cf75018d"",
+                                    ""AcceptanceDateTime"" : ISODate(""2026-06-25T10:00:00.000+00:00""),
+                                    ""DocumentType"" : ""PrivacyPolicy"",
+                                    ""Version"" : ""2026-06-25""
+                                }
+                            ],                                                                                                                                                 
                             ""Claims"" : [                                                                                                                                                                                                      
                                 {                                                                                                                                                                                                             
                                     ""_m"" : ""f7831985-dc0c-439f-b118-d7c511619a87"",                                                                                                                                                            
@@ -551,6 +565,11 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
                     var expectedDocumentMock = new Mock<UserWeb2>();
                     expectedDocumentMock.Setup(d => d.Id).Returns("6a317235d33d390f7d1e350e");
                     expectedDocumentMock.Setup(d => d.CreationDateTime).Returns(new DateTime(2026, 06, 16, 15, 56, 37, 411));
+                    expectedDocumentMock.Setup(d => d.AcceptedLegalDocuments).Returns(
+                    [
+                        new LegalAcceptance(LegalDocumentType.TermsOfService, "2026-06-25", new DateTime(2026, 06, 25, 10, 00, 00, DateTimeKind.Utc)),
+                        new LegalAcceptance(LegalDocumentType.PrivacyPolicy, "2026-06-25", new DateTime(2026, 06, 25, 10, 00, 00, DateTimeKind.Utc))
+                    ]);
                     expectedDocumentMock.Setup(d => d.EtherAddress).Returns("0xC2AE6f81f7DdBE4ed1904CAB954c6a4aEA28b76F");
                     expectedDocumentMock.Setup(d => d.EtherPreviousAddresses).Returns([]);
                     expectedDocumentMock.Setup(d => d.InvitedByAdmin).Returns(true);
@@ -1114,6 +1133,7 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
             // Assert.
             Assert.Equal(testElement.ExpectedModel.Id, result.Id);
             Assert.Equal(testElement.ExpectedModel.CreationDateTime, result.CreationDateTime);
+            Assert.Equal(testElement.ExpectedModel.AcceptedLegalDocuments, result.AcceptedLegalDocuments);
             Assert.Equal(testElement.ExpectedModel.Email, result.Email);
             Assert.Equal(testElement.ExpectedModel.EtherAddress, result.EtherAddress);
             Assert.Equal(testElement.ExpectedModel.EtherPreviousAddresses, result.EtherPreviousAddresses);
@@ -1130,6 +1150,7 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
             Assert.Equal(testElement.ExpectedModel.SharedInfoId, result.SharedInfoId);
             Assert.Equal(testElement.ExpectedModel.Username, result.Username);
             Assert.NotNull(result.Id);
+            Assert.NotNull(result.AcceptedLegalDocuments);
             Assert.NotNull(result.EtherPreviousAddresses);
             Assert.NotNull(result.NormalizedUsername);
             Assert.NotNull(result.Roles);

--- a/test/EthernaSSO.Tests/Configs/Validation/MustBeTrueAttributeTest.cs
+++ b/test/EthernaSSO.Tests/Configs/Validation/MustBeTrueAttributeTest.cs
@@ -1,0 +1,65 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Etherna.SSOServer.Configs.Validation
+{
+    [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method naming convention.")]
+    public class MustBeTrueAttributeTest
+    {
+        [Fact]
+        public void IsValid_WithTrue_ReturnsTrue()
+        {
+            // Assert.
+            Assert.True(new MustBeTrueAttribute().IsValid(true));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void IsValid_WithNotTrue_ReturnsFalse(object? value)
+        {
+            // Assert.
+            Assert.False(new MustBeTrueAttribute().IsValid(value));
+        }
+
+        [Fact]
+        public void AddValidation_EmitsDedicatedClientRule()
+        {
+            // The built-in unobtrusive "required" rule skips checkboxes, so the attribute must emit its
+            // own "mustbetrue" rule (matched by the adapter registered in Static/js/site.js) for the
+            // checkbox to be validated client-side.
+
+            // Arrange.
+            var metadataProvider = new EmptyModelMetadataProvider();
+            var metadata = metadataProvider.GetMetadataForType(typeof(bool));
+            var attributes = new Dictionary<string, string>();
+            var context = new ClientModelValidationContext(new ActionContext(), metadata, metadataProvider, attributes);
+            var attribute = new MustBeTrueAttribute { ErrorMessage = "You must accept." };
+
+            // Action.
+            attribute.AddValidation(context);
+
+            // Assert.
+            Assert.Equal("true", attributes["data-val"]);
+            Assert.Equal("You must accept.", attributes[$"data-val-{MustBeTrueAttribute.RuleName}"]);
+        }
+    }
+}


### PR DESCRIPTION
Require explicit acceptance of Terms of Service and Privacy Policy on both Web2 and Web3 registration, with a separate per-document checkbox validated client- and server-side. Persist proof of consent (document, version, timestamp) on the user as an append-only history, include it in the personal-data export, and add a Legal account page summarising what was accepted and when. Document versions and URLs are configuration-driven.