### PR TITLE
Encrypt web2 managed private keys at rest (ESSO-257)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Bugs and features are tracked in Jira project **ESSO** (https://etherna.atlassia
 ## General Principles
 
 - Keep commits clean: only include changes strictly necessary for the task at hand.
+- Keep `README.md` aligned: when a change touches configuration, features, build/run steps, or architecture, update `README.md` in the same change.
 - Never reference AI agents or assistants in commits or code — no agent names, no `Co-Authored-By` agent trailers, no "generated/assisted by" notes. Commit messages and code must read as the team's own work.
 - Exceptions to these conventions are accepted when strictly necessary or when they significantly improve code quality. Justify with a comment where needed.
 - All elements (usings, properties, methods, fields, enum members, etc.) are always alphabetically ordered within their respective sections.
@@ -89,6 +90,8 @@ Secondary/separator comments:
 ```csharp
 //no space, no capital, no ending period
 ```
+
+Comment only what helps a future reader: non-obvious behavior, intent, or a gotcha. Do **not** write narration of your own reasoning or decisions (e.g. "X isn't deployed yet, so we reuse the schema", "no new GUID needed because…") — that belongs in the commit message / PR description, never in committed code. If the code and section comments already make the intent clear, add nothing.
 
 ## Member Ordering Within a Class
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Configuration uses the standard ASP.NET Core model. Values are resolved, in incr
 
 Hierarchical keys use a separator: the colon form (`Section:SubSection:Key`) or the double-underscore form (`Section__SubSection__Key`), which is portable across all platforms. Array entries are indexed: `Section:Items:0`, `Section:Items:1`, …
 
-Secrets (`*Password`, `*ServiceKey`, `*Secret`, `Duende:IdentityServer:LicenseKey`, MongoDB credentials) must be supplied via environment variables or a secret store at deploy time — never committed. Values marked **set in prod** below have no entry in `appsettings.Production.json` and must therefore come from the environment.
+Secrets (`*Password`, `*ServiceKey`, `*Secret`, `Duende:IdentityServer:LicenseKey`, `Encryption:EtherManagedPrivateKey`, MongoDB credentials) must be supplied via environment variables or a secret store at deploy time — never committed. Values marked **set in prod** below have no entry in `appsettings.Production.json` and must therefore come from the environment.
 
 ### Hosting (ASP.NET Core built-ins)
 
@@ -134,6 +134,14 @@ Secrets (`*Password`, `*ServiceKey`, `*Secret`, `Duende:IdentityServer:LicenseKe
 | `Email:ServiceUser` | — | provider user (Mailtrap) |
 | `Email:DisplayName` | `Etherna` | sender display name |
 | `Email:SendingAddress` | `noreply@etherna.io` | sender address |
+
+### Encryption
+
+The Web2 managed-wallet private key (`UserWeb2.EtherManagedPrivateKey`) is stored encrypted at rest (AES-256-GCM). Existing managed keys become unreadable if this key is lost or changed.
+
+| Key | Default | Notes |
+|---|---|---|
+| `Encryption:EtherManagedPrivateKey` | — (**set in prod**) | **secret** — base64-encoded 32-byte AES-256 key (`openssl rand -base64 32`); a dev default ships in `appsettings.Development.json` |
 
 ### Newsletter
 

--- a/src/EthernaSSO.Persistence/ModelMaps/Sso/UserMap.cs
+++ b/src/EthernaSSO.Persistence/ModelMaps/Sso/UserMap.cs
@@ -19,6 +19,7 @@ using Etherna.MongODM.Core.Extensions;
 using Etherna.MongODM.Core.Serialization;
 using Etherna.MongODM.Core.Serialization.Serializers;
 using Etherna.SSOServer.Domain.Models;
+using Etherna.SSOServer.Persistence.Serializers;
 
 namespace Etherna.SSOServer.Persistence.ModelMaps.Sso
 {
@@ -26,6 +27,9 @@ namespace Etherna.SSOServer.Persistence.ModelMaps.Sso
     {
         public void Register(IDbContext dbContext)
         {
+            var etherManagedPrivateKeySerializer = new EncryptedStringSerializer(
+                ((SsoDbContext)dbContext).EtherManagedPrivateKeyEncryptionKey);
+            
             dbContext.MapRegistry.AddModelMap<UserBase>("a492aaa7-196c-4ec0-8fb5-255d099d0b9f", mm =>
             {
                 mm.AutoMap();
@@ -54,6 +58,9 @@ namespace Etherna.SSOServer.Persistence.ModelMaps.Sso
                 mm.GetMemberMap(u => u.EtherManagedPrivateKey).SetIgnoreIfNull(true);
                 mm.GetMemberMap(u => u.IsAuthenticatorAppEnabled).SetIgnoreIfDefault(true);
                 mm.GetMemberMap(u => u.PasswordHash).SetIgnoreIfNull(true);
+
+                // Set members with custom serializers.
+                mm.SetMemberSerializer(u => u.EtherManagedPrivateKey, etherManagedPrivateKeySerializer);
             })
                 .AddSecondarySchema("2ccb567f-63cc-4fb3-b66e-a51fb4ff1bfe",
                     mm =>

--- a/src/EthernaSSO.Persistence/Serializers/EncryptedStringSerializer.cs
+++ b/src/EthernaSSO.Persistence/Serializers/EncryptedStringSerializer.cs
@@ -1,0 +1,92 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongoDB.Bson.Serialization;
+using Etherna.MongoDB.Bson.Serialization.Serializers;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Etherna.SSOServer.Persistence.Serializers
+{
+    /// <summary>
+    /// Serializes a string encrypting it at rest with AES-256-GCM, storing it base64-encoded.
+    /// The stored payload layout is: nonce (12 bytes) | tag (16 bytes) | ciphertext.
+    /// </summary>
+    public sealed class EncryptedStringSerializer : SerializerBase<string>
+    {
+        // Consts.
+        private const int KeySize = 32; //AES-256
+        private const int NonceSize = 12; //AesGcm standard nonce size
+        private const int TagSize = 16; //AesGcm max tag size
+
+        // Fields.
+        private readonly byte[] key;
+        private readonly StringSerializer stringSerializer = new();
+
+        // Constructor.
+        public EncryptedStringSerializer(string base64Key)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(base64Key);
+
+            key = Convert.FromBase64String(base64Key);
+            if (key.Length != KeySize)
+                throw new ArgumentException(
+                    $"Encryption key must be {KeySize} bytes long (base64-encoded)", nameof(base64Key));
+        }
+
+        // Methods.
+        public string Decrypt(string base64Payload)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(base64Payload);
+
+            var payload = Convert.FromBase64String(base64Payload);
+            var nonce = payload.AsSpan(0, NonceSize);
+            var tag = payload.AsSpan(NonceSize, TagSize);
+            var ciphertext = payload.AsSpan(NonceSize + TagSize);
+            var plaintext = new byte[ciphertext.Length];
+
+            using var aesGcm = new AesGcm(key, TagSize);
+            aesGcm.Decrypt(nonce, ciphertext, tag, plaintext);
+
+            return Encoding.UTF8.GetString(plaintext);
+        }
+
+        public override string Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args) =>
+            Decrypt(stringSerializer.Deserialize(context, args));
+
+        public string Encrypt(string plaintext)
+        {
+            ArgumentNullException.ThrowIfNull(plaintext);
+
+            var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+            var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+            var tag = new byte[TagSize];
+            var ciphertext = new byte[plaintextBytes.Length];
+
+            using var aesGcm = new AesGcm(key, TagSize);
+            aesGcm.Encrypt(nonce, plaintextBytes, ciphertext, tag);
+
+            var payload = new byte[NonceSize + TagSize + ciphertext.Length];
+            nonce.CopyTo(payload, 0);
+            tag.CopyTo(payload, NonceSize);
+            ciphertext.CopyTo(payload, NonceSize + TagSize);
+
+            return Convert.ToBase64String(payload);
+        }
+
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, string value) =>
+            stringSerializer.Serialize(context, args, Encrypt(value));
+    }
+}

--- a/src/EthernaSSO.Persistence/Settings/SsoDbEncryptionSettings.cs
+++ b/src/EthernaSSO.Persistence/Settings/SsoDbEncryptionSettings.cs
@@ -1,22 +1,24 @@
-﻿// Copyright 2021-present Etherna SA
+// Copyright 2021-present Etherna SA
 // This file is part of Etherna Sso.
-// 
+//
 // Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Affero General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
 // If not, see <https://www.gnu.org/licenses/>.
 
 namespace Etherna.SSOServer.Persistence.Settings
 {
-    public class SsoDbSeedSettings
+    public class SsoDbEncryptionSettings
     {
-        public string FirstAdminUsername { get; set; } = null!;
-        public string FirstAdminPassword { get; set; } = null!;
+        /// <summary>
+        /// Base64-encoded AES-256 key (32 bytes) used to encrypt the web2 ether managed private key at rest.
+        /// </summary>
+        public string EtherManagedPrivateKey { get; set; } = null!;
     }
 }

--- a/src/EthernaSSO.Persistence/SsoDbContext.cs
+++ b/src/EthernaSSO.Persistence/SsoDbContext.cs
@@ -34,6 +34,7 @@ using System.Threading.Tasks;
 namespace Etherna.SSOServer.Persistence
 {
     public class SsoDbContext(
+        SsoDbEncryptionSettings encryptionSettings,
         IEventDispatcher eventDispatcher,
         SsoDbSeedSettings seedSettings,
         IServiceProvider serviceProvider)
@@ -160,6 +161,7 @@ namespace Etherna.SSOServer.Persistence
         public override IEnumerable<DocumentMigration> DocumentMigrationList => Array.Empty<DocumentMigration>();
 
         //other properties
+        public string EtherManagedPrivateKeyEncryptionKey { get; } = encryptionSettings.EtherManagedPrivateKey;
         public IEventDispatcher EventDispatcher { get; } = eventDispatcher;
 
         // Protected properties.

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/Role.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/Role.cshtml.cs
@@ -28,7 +28,7 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         {
             [Required]
             [Display(Name = "Role name")]
-            public string Name { get; set; } = default!;
+            public string Name { get; set; } = null!;
         }
 
         // Fields.
@@ -44,7 +44,7 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         public string? Id { get; private set; }
 
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task OnGetAsync(string? id)

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/RoleUsers.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/RoleUsers.cshtml.cs
@@ -65,8 +65,8 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         public int CurrentPage { get; set; }
         public long MaxPage { get; set; }
         public string? Query { get; set; }
-        public string RoleId { get; private set; } = default!;
-        public string RoleName { get; private set; } = default!;
+        public string RoleId { get; private set; } = null!;
+        public string RoleName { get; private set; } = null!;
         public List<UserDto> Users { get; } = new();
 
         // Methods.

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/User.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/User.cshtml.cs
@@ -89,7 +89,7 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
 
             [Required]
             [RegularExpression(UsernameHelper.UsernameRegex)]
-            public string Username { get; set; } = default!;
+            public string Username { get; set; } = null!;
 
             [Display(Name = "Max allowed clients")]
             [Range(0, 100)]

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserChangePassword.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserChangePassword.cshtml.cs
@@ -29,12 +29,12 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         public class InputModel
         {
             [Required]
-            public string Password { get; set; } = default!;
+            public string Password { get; set; } = null!;
 
             [Required]
             [Compare(nameof(Password))]
             [Display(Name = "Confirm password")]
-            public string ConfirmPassword { get; set; } = default!;
+            public string ConfirmPassword { get; set; } = null!;
         }
 
         // Fields.
@@ -51,11 +51,11 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         }
 
         // Properties.
-        public string Id { get; private set; } = default!;
-        public string Username { get; private set; } = default!;
+        public string Id { get; private set; } = null!;
+        public string Username { get; private set; } = null!;
 
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task<IActionResult> OnGetAsync(string id)

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserClaims.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserClaims.cshtml.cs
@@ -60,14 +60,14 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         }
 
         // Properties.
-        public string Id { get; private set; } = default!;
+        public string Id { get; private set; } = null!;
         public IEnumerable<ClaimDto> Claims { get; private set; } = Array.Empty<ClaimDto>();
         public int CurrentPage { get; private set; }
         public int MaxPage { get; private set; }
-        public string Username { get; private set; } = default!;
+        public string Username { get; private set; } = null!;
 
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task OnGetAsync(string id, int? p)

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserDelete.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserDelete.cshtml.cs
@@ -37,8 +37,8 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         }
 
         // Properties.
-        public string Id { get; private set; } = default!;
-        public string Username { get; private set; } = default!;
+        public string Id { get; private set; } = null!;
+        public string Username { get; private set; } = null!;
 
         // Methods.
         public async Task OnGetAsync(string id)

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserRoles.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserRoles.cshtml.cs
@@ -55,13 +55,13 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         }
 
         // Properties.
-        public IEnumerable<RoleDto> AllRoles { get; private set; } = default!;
+        public IEnumerable<RoleDto> AllRoles { get; private set; } = null!;
         public int CurrentPage { get; private set; }
         public int MaxPage { get; private set; }
-        public string RoleId { get; private set; } = default!;
-        public string UserId { get; private set; } = default!;
-        public string Username { get; private set; } = default!;
-        public IEnumerable<RoleDto> UserRoles { get; private set; } = default!;
+        public string RoleId { get; private set; } = null!;
+        public string UserId { get; private set; } = null!;
+        public string Username { get; private set; } = null!;
+        public IEnumerable<RoleDto> UserRoles { get; private set; } = null!;
 
         // Methods.
         public async Task OnGetAsync(string id, int? p)

--- a/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserRolesDelete.cshtml.cs
+++ b/src/EthernaSSO/Areas/Admin/Pages/IdentityServer/UserRolesDelete.cshtml.cs
@@ -33,10 +33,10 @@ namespace Etherna.SSOServer.Areas.Admin.Pages.IdentityServer
         }
 
         // Properties.
-        public string RoleId { get; private set; } = default!;
-        public string RoleName { get; private set; } = default!;
-        public string UserId { get; private set; } = default!;
-        public string Username { get; private set; } = default!;
+        public string RoleId { get; private set; } = null!;
+        public string RoleName { get; private set; } = null!;
+        public string UserId { get; private set; } = null!;
+        public string Username { get; private set; } = null!;
 
         // Methods.
         public async Task OnGetAsync(string roleId, string userId)

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -36,7 +36,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         {
             [Required]
             [EmailAddress]
-            public string Email { get; set; } = default!;
+            public string Email { get; set; } = null!;
         }
 
         // Fields.
@@ -57,7 +57,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
 
         // Properties.
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task<IActionResult> OnPostAsync()

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -36,7 +36,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
             [Required]
             [DataType(DataType.Text)]
             [Display(Name = "Recovery Code")]
-            public string RecoveryCode { get; set; } = default!;
+            public string RecoveryCode { get; set; } = null!;
         }
 
         // Fields.
@@ -54,7 +54,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
 
         // Properties.
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         public string? ReturnUrl { get; set; }
 

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -60,7 +60,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
 
         // Properties.
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
         public string? LogoutId { get; set; }
 
         // Methods.

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -32,18 +32,18 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
             [Required]
             [DataType(DataType.Password)]
             [Display(Name = "Current password")]
-            public string OldPassword { get; set; } = default!;
+            public string OldPassword { get; set; } = null!;
 
             [Required]
             [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
             [DataType(DataType.Password)]
             [Display(Name = "New password")]
-            public string NewPassword { get; set; } = default!;
+            public string NewPassword { get; set; } = null!;
 
             [DataType(DataType.Password)]
             [Display(Name = "Confirm new password")]
             [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
-            public string ConfirmPassword { get; set; } = default!;
+            public string ConfirmPassword { get; set; } = null!;
         }
 
         // Fields.
@@ -64,7 +64,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
 
         // Properties.
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task<IActionResult> OnGetAsync()

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Developer/ClientEdit.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/Developer/ClientEdit.cshtml.cs
@@ -60,7 +60,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage.Developer
             [Required]
             [MaxLength(ClientApp.ClientNameMaxLength)]
             [Display(Name = "Client name")]
-            public string ClientName { get; set; } = default!;
+            public string ClientName { get; set; } = null!;
 
             [MaxLength(ClientApp.DescriptionMaxLength)]
             [Display(Name = "Description")]
@@ -98,7 +98,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage.Developer
         public IEnumerable<string> ClientCredentialAlwaysClaims => [EthernaClaimTypes.EtherAddress];
 
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task<IActionResult> OnGetAsync(string id)

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/SetPassword.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Manage/SetPassword.cshtml.cs
@@ -31,12 +31,12 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
             [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
             [DataType(DataType.Password)]
             [Display(Name = "New password")]
-            public string NewPassword { get; set; } = default!;
+            public string NewPassword { get; set; } = null!;
 
             [DataType(DataType.Password)]
             [Display(Name = "Confirm new password")]
             [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
-            public string ConfirmPassword { get; set; } = default!;
+            public string ConfirmPassword { get; set; } = null!;
         }
 
         // Fields.
@@ -54,7 +54,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account.Manage
 
         // Properties.
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         // Methods.
         public async Task<IActionResult> OnGetAsync()

--- a/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml.cs
+++ b/src/EthernaSSO/Areas/Identity/Pages/Account/Web3Login.cshtml.cs
@@ -122,7 +122,7 @@ namespace Etherna.SSOServer.Areas.Identity.Pages.Account
         public string? ErrorMessage { get; set; }
 
         [BindProperty]
-        public InputModel Input { get; set; } = default!;
+        public InputModel Input { get; set; } = null!;
 
         public bool DuplicateUsername { get; private set; }
         public EthAddress? EtherAddress { get; private set; }

--- a/src/EthernaSSO/Program.cs
+++ b/src/EthernaSSO/Program.cs
@@ -472,6 +472,7 @@ namespace Etherna.SSOServer
             services.Configure<EmailOptions>(config.GetSection("Email") ?? throw new ServiceConfigurationException());
             services.Configure<LegalOptions>(config.GetSection("Legal") ?? throw new ServiceConfigurationException());
             services.Configure<NewsletterOptions>(config.GetSection("Newsletter") ?? throw new ServiceConfigurationException());
+            services.Configure<SsoDbEncryptionSettings>(config.GetSection("Encryption") ?? throw new ServiceConfigurationException());
             services.Configure<SsoDbSeedSettings>(config.GetSection("DbSeed") ?? throw new ServiceConfigurationException());
             
             // Configure api handler.
@@ -495,9 +496,10 @@ namespace Etherna.SSOServer
             })
                 .AddDbContext<ISsoDbContext, SsoDbContext>(sp =>
                 {
+                    var encryptionSettings = sp.GetRequiredService<IOptions<SsoDbEncryptionSettings>>();
                     var eventDispatcher = sp.GetRequiredService<IEventDispatcher>();
                     var seedSettings = sp.GetRequiredService<IOptions<SsoDbSeedSettings>>();
-                    return new SsoDbContext(eventDispatcher, seedSettings.Value, sp);
+                    return new SsoDbContext(encryptionSettings.Value, eventDispatcher, seedSettings.Value, sp);
                 },
                 options =>
                 {

--- a/src/EthernaSSO/appsettings.Development.json
+++ b/src/EthernaSSO/appsettings.Development.json
@@ -24,6 +24,11 @@
     //"ServiceUser": "service_user"
   },
 
+  "Encryption": {
+    //development-only default key; production must override Encryption__EtherManagedPrivateKey via the deploy stack
+    "EtherManagedPrivateKey": "El2wSzy+oZO99lGzaffFh3p04CTQswwXppGqDrg02w0="
+  },
+
   "Fido2": {
     "ServerDomain": "localhost",
     "Origins": [ "https://localhost:44379" ]

--- a/test/EthernaSSO.Persistence.Tests/ModelMaps/SsoDbContextDeserializationTest.cs
+++ b/test/EthernaSSO.Persistence.Tests/ModelMaps/SsoDbContextDeserializationTest.cs
@@ -24,6 +24,7 @@ using Etherna.SSOServer.Domain.Models.ClientAppAgg;
 using Etherna.SSOServer.Domain.Models.Fido2CredentialAgg;
 using Etherna.SSOServer.Domain.Models.UserAgg;
 using Etherna.SSOServer.Persistence.Helpers;
+using Etherna.SSOServer.Persistence.Serializers;
 using Etherna.SSOServer.Persistence.Settings;
 using Moq;
 using System;
@@ -39,6 +40,9 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
     [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test method naming convention.")]
     public class SsoDbContextDeserializationTest
     {
+        // Consts.
+        private const string EncryptionKey = "OPYwOt2ZP5n6WaItPi9lny/pbq0Rv+3x7u1+IB7HFKU=";
+
         // Fields.
         private readonly SsoDbContext dbContext;
         private readonly Mock<IEventDispatcher> eventDispatcherMock = new();
@@ -47,11 +51,12 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
         // Constructor.
         public SsoDbContextDeserializationTest()
         {
+            var encryptionSettings = new SsoDbEncryptionSettings { EtherManagedPrivateKey = EncryptionKey };
             var serviceProviderMock = new Mock<IServiceProvider>();
             var ssoDbSeedSettingsMock = new Mock<SsoDbSeedSettings>();
 
             // Setup dbContext.
-            dbContext = new SsoDbContext(eventDispatcherMock.Object, ssoDbSeedSettingsMock.Object, serviceProviderMock.Object);
+            dbContext = new SsoDbContext(encryptionSettings, eventDispatcherMock.Object, ssoDbSeedSettingsMock.Object, serviceProviderMock.Object);
 
             DbContextMockHelper.InitializeDbContextMock(dbContext, mongoDatabaseMock);
         }
@@ -473,8 +478,10 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
             {
                 var tests = new List<DeserializationTestElement<UserBase, SsoDbContext>>();
 
-                // "c54bb1fe-a7e2-4069-b91c-1065b16ca4da" - v0.4.0 - UserWeb2 (current schema, with a FIDO2 credential)
+                // "c54bb1fe-a7e2-4069-b91c-1065b16ca4da" - v0.4.0 - UserWeb2 (active schema, ether managed private key encrypted at rest, with a FIDO2 credential)
                 {
+                    var encryptedManagedPrivateKey = new EncryptedStringSerializer(EncryptionKey)
+                        .Encrypt("54e0bb8ccbb95719898f179b7422f4bf3f053c789a3e1c54b8d8ee81dead1224");
                     var sourceDocument =
                         @"{
                             ""_id"" : ObjectId(""6a317235d33d390f7d1e350e""),                                                                                                                                                                     
@@ -541,7 +548,7 @@ namespace Etherna.SSOServer.Persistence.ModelMaps
                             ""Username"" : ""admin"",                                                                                                                                                                                             
                             ""AccessFailedCount"" : 3,                                                                                                                                                                                          
                             ""AuthenticatorKey"" : null,                                                                                                                                                                                        
-                            ""EtherManagedPrivateKey"" : ""54e0bb8ccbb95719898f179b7422f4bf3f053c789a3e1c54b8d8ee81dead1224"",                                                                                                                    
+                            ""EtherManagedPrivateKey"" : """ + encryptedManagedPrivateKey + @""",                                                                                                                    
                             ""Fido2Credentials"" : [                                                                                                                                                                                            
                                 {                                                                                                                                                                                                             
                                     ""_m"" : ""194013ae-d113-48f8-aea7-e8cf169186fa"",                                                                                                                                                            


### PR DESCRIPTION
Store UserWeb2.EtherManagedPrivateKey encrypted at rest with AES-256-GCM via a dedicated EncryptedStringSerializer. The key is read from the Encryption:EtherManagedPrivateKey config (dev default in appsettings.Development.json, supplied via environment in production). Encryption is applied in place on the unreleased v0.4.0 schema; the deployed schema keeps reading the legacy cleartext value, so existing documents re-encrypt on their next save.

Also align required reference members to = null! instead of = default! across the codebase, document the new key in README, and record the README-alignment and comment conventions in AGENTS.