### PR TITLE
Add support for configuration-defined IdentityServer clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ source together with its build and deployment configuration.
   Windows Hello, …) and single-use recovery codes; at login a registered security key is preferred when no
   authenticator app is configured.
 - **OpenID Connect provider** — built on Duende IdentityServer; issues identity/access tokens to the Etherna
-  services, with both in-memory and database-backed client registrations.
+  services, with in-memory, configuration-defined and database-backed client registrations.
 - **REST API** — endpoints under `/api` (including API-key authentication) with an interactive Scalar
   reference at `/scalar/sso03`.
 - **Admin area** — user and client management for administrators.
@@ -171,6 +171,7 @@ Optional, opt-in only: a user can subscribe to the newsletter during email verif
 | `IdServer:SsoServer:AllowUnsafeConnection` | dev only — allow an http authority |
 | `IdServer:SsoServer:Clients:Webapp:Secret` | **secret** — SSO web-app client secret |
 | `IdServer:Clients:<App>:…:Secret` | **secret** — downstream client secrets (Credit, Gateway, Index, …); client ids and base urls live in `appsettings*.json` |
+| `IdServer:ConfigClients:<n>:…` | additional clients defined entirely by configuration (`ClientId`, `ClientName`, `Secret`, `AllowedGrantTypes`, `AllowedScopes`, `RedirectUris`, `PostLogoutRedirectUris`, `AllowOfflineAccess`); used to host environment-specific clients in `appsettings.Development.json` — in production such clients are created from the developer editor and live on db |
 
 ### Logging & networking
 

--- a/src/EthernaSSO/Configs/IdentityServer/ConfigClientDefinition.cs
+++ b/src/EthernaSSO/Configs/IdentityServer/ConfigClientDefinition.cs
@@ -1,0 +1,36 @@
+// Copyright 2021-present Etherna SA
+// This file is part of Etherna Sso.
+//
+// Etherna Sso is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// Etherna Sso is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along with Etherna Sso.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Etherna.SSOServer.Configs.IdentityServer
+{
+    /// <summary>
+    /// An IdentityServer client defined entirely by configuration (see "IdServer:ConfigClients").
+    /// Used to host environment-specific clients in configuration files, instead of hardcoding
+    /// them in <see cref="IdServerConfig"/>.
+    /// </summary>
+    public class ConfigClientDefinition
+    {
+        // Properties.
+        public IEnumerable<string> AllowedGrantTypes { get; set; } = [];
+        public IEnumerable<string> AllowedScopes { get; set; } = [];
+        public bool AllowOfflineAccess { get; set; }
+        public string ClientId { get; set; } = null!;
+        public string? ClientName { get; set; }
+        public IEnumerable<string> PostLogoutRedirectUris { get; set; } = [];
+        public IEnumerable<string> RedirectUris { get; set; } = [];
+        public string? Secret { get; set; }
+    }
+}

--- a/src/EthernaSSO/Configs/IdentityServer/IdServerConfig.cs
+++ b/src/EthernaSSO/Configs/IdentityServer/IdServerConfig.cs
@@ -87,6 +87,8 @@ namespace Etherna.SSOServer.Configs.IdentityServer
         // Fields.
         private readonly string apiKey_ClientId;
 
+        private readonly ConfigClientDefinition[] configClientDefinitions;
+
         private readonly string ethernaCredit_BaseUrl;
         private readonly string ethernaCredit_Sso_ClientId;
         private readonly string ethernaCredit_Sso_Secret;
@@ -136,6 +138,8 @@ namespace Etherna.SSOServer.Configs.IdentityServer
             ArgumentNullException.ThrowIfNull(configuration);
 
             apiKey_ClientId = configuration["IdServer:Clients:ApiKey:ClientId"] ?? throw new ServiceConfigurationException();
+
+            configClientDefinitions = configuration.GetSection("IdServer:ConfigClients").Get<ConfigClientDefinition[]>() ?? [];
 
             ethernaCredit_BaseUrl = configuration["IdServer:Clients:EthernaCredit:BaseUrl"] ?? throw new ServiceConfigurationException();
             ethernaCredit_Sso_ClientId = configuration["IdServer:Clients:EthernaCredit:Clients:SsoServer:ClientId"] ?? throw new ServiceConfigurationException();
@@ -768,7 +772,10 @@ namespace Etherna.SSOServer.Configs.IdentityServer
                 // Allow token refresh.
                 AllowOfflineAccess = true,
                 RefreshTokenUsage = TokenUsage.OneTimeOnly //because client have not secret
-            }
+            },
+
+            //clients defined by configuration (see "IdServer:ConfigClients")
+            .. configClientDefinitions.Select(BuildConfigClient)
         ];
 
         public IEnumerable<IdentityResource> IdResources =>
@@ -788,6 +795,32 @@ namespace Etherna.SSOServer.Configs.IdentityServer
             field ??= BuildScopeUserClaimsMap();
 
         // Helpers.
+        private static Client BuildConfigClient(ConfigClientDefinition definition)
+        {
+            if (string.IsNullOrEmpty(definition.ClientId))
+                throw new ServiceConfigurationException();
+
+            return new Client
+            {
+                ClientId = definition.ClientId,
+                ClientName = definition.ClientName,
+                ClientSecrets = definition.Secret is null ? [] : [new Secret(definition.Secret.Sha256())],
+                RequireClientSecret = definition.Secret is not null,
+
+                AllowedGrantTypes = [.. definition.AllowedGrantTypes],
+
+                //where to redirect to after login
+                RedirectUris = [.. definition.RedirectUris],
+
+                //where to redirect to after logout
+                PostLogoutRedirectUris = [.. definition.PostLogoutRedirectUris],
+
+                AllowedScopes = [.. definition.AllowedScopes],
+
+                AllowOfflineAccess = definition.AllowOfflineAccess
+            };
+        }
+
         private Dictionary<string, ICollection<string>> BuildScopeUserClaimsMap()
         {
             var map = new Dictionary<string, ICollection<string>>();

--- a/src/EthernaSSO/appsettings.Development.json
+++ b/src/EthernaSSO/appsettings.Development.json
@@ -83,6 +83,18 @@
       }
     },
 
+    //development-only clients, defined entirely by configuration.
+    //in production these clients are created from the developer editor, and live on db.
+    "ConfigClients": [
+      {
+        "ClientId": "ethernaIndexServicesClientId",
+        "ClientName": "Etherna Index to Services (clientCredentials)",
+        "Secret": "ethernaIndexServicesClientSecret",
+        "AllowedGrantTypes": [ "client_credentials" ],
+        "AllowedScopes": [ "userApi.gateway" ]
+      }
+    ],
+
     "SsoServer": {
       //"AllowUnsafeConnection": false,
       "BaseUrl": "https://localhost:44379",


### PR DESCRIPTION
Introduce `ConfigClientDefinition` to define IdentityServer clients via configuration (e.g., `appsettings.Development.json`) for development environments. Update `IdServerConfig` to handle these clients dynamically while retaining database-backed client handling for production. Update README to document the new configuration option.